### PR TITLE
remove old case study sidebar and replace with projects back button

### DIFF
--- a/components/NavSidebar.js
+++ b/components/NavSidebar.js
@@ -1,29 +1,20 @@
 import cx from 'classnames';
 import { useTranslation } from 'gatsby-plugin-react-i18next';
 import React from 'react';
+import { Icon } from './Icon';
 
 import { DataContext } from '../contexts/DataContext';
 import { useSiteMenus } from '../hooks/use-site-menus';
 import { Link, LinkMenu } from './Link';
 
-const NavSidebarCaseStudySubMenu = ({ teams }) => {
-  const caseStudies = teams.filter(team => 'caseStudy' in team);
+const NavSidebarCaseStudySubMenu = ({ projects }) => {
 
   return (
     <>
-      <span className="px-6 p-4 block bg-substrateGray dark:bg-gray-700 font-bold mb-2">Case Studies</span>
-      <ul className="p-0 m-0 list-none">
-        {caseStudies &&
-          caseStudies.map(({ name, caseStudy }, idx) => {
-            return (
-              <li className="font-medium p-0 m-0" key={idx}>
-                <Link to={`/ecosystem/projects/${caseStudy}`}>
-                  <p className={cx('px-6 p-3 block hover:font-bold m-0')}>{name}</p>
-                </Link>
-              </li>
-            );
-          })}
-      </ul>
+      <Link to='/ecosystem/projects/' className="px-6 p-4 block bg-substrateGray dark:bg-gray-700 font-bold mb-2">
+        <Icon name="arrow-back" width="16" height="16" className="fill-current text-black dark:text-white inline text-sm" />
+         {' '} Back to Projects
+        </Link>
     </>
   );
 };
@@ -57,6 +48,7 @@ const NavSidebarSubMenu = ({ parent, category }) => {
                   internal={subMenuItem.internal}
                 >
                   {t(subMenuItem.id)}
+                  hello
                 </LinkMenu>
               </li>
             );
@@ -71,7 +63,7 @@ const NavSidebar = ({ data }) => {
     <DataContext.Consumer>
       {({ pathArray }) => (
         <nav className={cx('navSidebar pt-10 pb-5')}>
-          {pathArray[2] === 'case-studies' ? (
+          {pathArray[1] === 'projects' ? (
             <NavSidebarCaseStudySubMenu teams={data} />
           ) : (
             <NavSidebarSubMenu parent={pathArray[0]} category={pathArray[1]} />


### PR DESCRIPTION
This is a work in progress to address the sidebar layout on the new projects page on substrate.io.

https://github.com/paritytech/substrate-website/pull/266